### PR TITLE
Improve comment highlighting

### DIFF
--- a/Syntaxes/Ini.plist
+++ b/Syntaxes/Ini.plist
@@ -48,7 +48,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(^[ \t]+)?(?=;)</string>
+			<string>^([ \t]+)?(?=;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
`;` should only indicate a comment if it's at the start of a line.

```ini
; This is a comment

; Here it's used as list separator
key = value1;value2;value3
```

**Example from glib**
```ini
[Another Group]
Numbers=2;20;-200;0
Booleans=true;false;true;true
```
https://developer.gnome.org/glib/stable/glib-Key-value-file-parser.html#glib-Key-value-file-parser.description

**Additional links**
https://en.wikipedia.org/wiki/INI_file#Comments