### PR TITLE
Improve keyword highlighting

### DIFF
--- a/Syntaxes/Ini.plist
+++ b/Syntaxes/Ini.plist
@@ -82,19 +82,19 @@
 		<dict>
 			<key>captures</key>
 			<dict>
-				<key>1</key>
+				<key>2</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.other.definition.ini</string>
 				</dict>
-				<key>2</key>
+				<key>3</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.separator.key-value.ini</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b([a-zA-Z0-9_.-]+)\b\s*(=)</string>
+			<string>^([ \t]+)?\b([a-zA-Z0-9_.- '"]+)\b\s*(=)</string>
 		</dict>
 		<dict>
 			<key>captures</key>

--- a/Syntaxes/Ini.plist
+++ b/Syntaxes/Ini.plist
@@ -94,7 +94,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^([ \t]+)?\b([a-zA-Z0-9_.- '"]+)\b\s*(=)</string>
+			<string>^([ \t]+)?\b((?:(?:[a-zA-Z0-9'"]+)(?:[_.- ]?))+)\b\s*(=)</string>
 		</dict>
 		<dict>
 			<key>captures</key>


### PR DESCRIPTION
Although uncommon, keywords are allowed to contain spaces and quotation marks as well. Additionally keywords should only be matched at the start of a line, not inside a list that contains `=`, for example.

```ini
valid keyword = "Hello World"
"also valid keyword" = 1
it's a keyword = true

list =
    var1,var2=2,var3
```

**Examples**
Python config parser: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure

https://www.webdeveloper.com/d/299789-parse-ini-files-with-spaces/5
https://www.phpclasses.org/package/9413-PHP-Load-and-edit-configuration-INI-format-files.html -> Section: `Example .ini file` 

--
Additionally, only highlight as keyword if not two delimiters directly follow each other.

```ini
valid-keyword = 1
probably--a--mistake = 2
```