### PR TITLE
Improve key-value separator highlighting

### DIFF
--- a/Syntaxes/Ini.plist
+++ b/Syntaxes/Ini.plist
@@ -94,7 +94,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b([a-zA-Z0-9_.-]+)\b\s*(?:([=:])(?!\2))</string>
+			<string>\b([a-zA-Z0-9_.-]+)\b\s*(?:([=])(?!\2))</string>
 		</dict>
 		<dict>
 			<key>captures</key>

--- a/Syntaxes/Ini.plist
+++ b/Syntaxes/Ini.plist
@@ -94,7 +94,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b([a-zA-Z0-9_.-]+)\b\s*(=)</string>
+			<string>\b([a-zA-Z0-9_.-]+)\b\s*(?:([=:])(?!\2))</string>
 		</dict>
 		<dict>
 			<key>captures</key>


### PR DESCRIPTION
~Add `:` as additional `key-value` separator.~ Additionally, don't match if two follow each other: `==`.

```ini
; probably not a key
version==1.2.3
```