### PR TITLE
remove "#" as a valid comment character

### DIFF
--- a/Preferences/Miscellaneous.tmPreferences
+++ b/Preferences/Miscellaneous.tmPreferences
@@ -35,12 +35,6 @@
 				<key>value</key>
 				<string>; </string>
 			</dict>
-			<dict>
-				<key>name</key>
-				<string>TM_COMMENT_START_2</string>
-				<key>value</key>
-				<string># </string>
-			</dict>
 		</array>
 		<key>smartTypingPairs</key>
 		<array>

--- a/Syntaxes/Ini.plist
+++ b/Syntaxes/Ini.plist
@@ -15,39 +15,6 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>(^[ \t]+)?(?=#)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.whitespace.comment.leading.ini</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?!\G)</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>#</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.comment.ini</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>\n</string>
-					<key>name</key>
-					<string>comment.line.number-sign.ini</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>begin</key>
 			<string>(^[ \t]+)?(?=;)</string>
 			<key>beginCaptures</key>
 			<dict>


### PR DESCRIPTION
The Info.plist references http://en.wikipedia.org/wiki/INI_file which says only `;` is allowed for comments.  This removes the option for `#` as a comment in INI.